### PR TITLE
Add blueprint background style

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -3,3 +3,28 @@
   padding: 0;
   box-sizing: border-box;
 }
+
+body {
+  margin: 0;
+  overflow: hidden;
+  background-color: #0a0a0a;
+  background-image: linear-gradient(rgba(255, 255, 255, 0.15) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.15) 1px, transparent 1px),
+    linear-gradient(rgba(255, 255, 255, 0.1) 10px, transparent 10px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.1) 10px, transparent 10px);
+  background-size: 50px 50px, 50px 50px, 250px 250px, 250px 250px;
+}
+
+canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: transparent;
+}
+
+.dg.ac {
+  z-index: 1000 !important;
+}


### PR DESCRIPTION
## Summary
- style the body and canvas elements to show blueprint-style grid background

## Testing
- `npm run build` *(fails: parcel not found)*
- `npm install` *(fails: network access)*

------
https://chatgpt.com/codex/tasks/task_e_68505c7946e88323bdb57c08471231fb