### PR TITLE
Fix fullscreen shader alpha

### DIFF
--- a/src/scripts/gl/shaders/fullscreen.frag
+++ b/src/scripts/gl/shaders/fullscreen.frag
@@ -16,5 +16,5 @@ void main() {
     color2,
     1.0 - pattern
   );
-  gl_FragColor = vec4(vec3(0.0), 1.0);
+  gl_FragColor = vec4(vec3(0.0), 0.0);
 }


### PR DESCRIPTION
## Summary
- update `fullscreen.frag` so the fragment output has alpha 0.0

## Testing
- `npm start` *(fails: `parcel` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685063266198832392fbf2e117af9028