### PR TITLE
Fix GLSL imports with bundle-text loader

### DIFF
--- a/.parcelrc
+++ b/.parcelrc
@@ -1,6 +1,6 @@
 {
   "extends": "@parcel/config-default",
   "transformers": {
-    "*.{glsl,frag,vert}": ["@parcel/transformer-glsl"]
+    "*.glsl": ["@parcel/transformer-bundle-text"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "glslify-bundle": "^5.1.1",
     "glslify-deps": "^1.3.2",
     "parcel": "^2.15.4",
-    "sass": "^1.32.13"
+    "sass": "^1.32.13",
+    "@parcel/transformer-bundle-text": "^2.15.4"
   },
   "@parcel/transformer-glsl": {
     "version": 100

--- a/src/scripts/gl/index.js
+++ b/src/scripts/gl/index.js
@@ -7,12 +7,12 @@ import store from '../store';
 
 import FBO from './FBO';
 
-import simVertex from './shaders/simulation.vert.glsl';
-import simFragment from './shaders/simulation.frag.glsl';
-import particlesVertex from './shaders/particles.vert.glsl';
-import particlesFragment from './shaders/particles.frag.glsl';
-import fullScreenVertex from './shaders/fullscreen.vert.glsl';
-import fullScreenFragment from './shaders/fullscreen.frag.glsl';
+import simVertex from 'bundle-text:./shaders/simulation.vert.glsl';
+import simFragment from 'bundle-text:./shaders/simulation.frag.glsl';
+import particlesVertex from 'bundle-text:./shaders/particles.vert.glsl';
+import particlesFragment from 'bundle-text:./shaders/particles.frag.glsl';
+import fullScreenVertex from 'bundle-text:./shaders/fullscreen.vert.glsl';
+import fullScreenFragment from 'bundle-text:./shaders/fullscreen.frag.glsl';
 
 import { getRandomSpherePoint } from '../utils';
 


### PR DESCRIPTION
## Summary
- add `@parcel/transformer-bundle-text` as a dev dependency
- configure Parcel to bundle GLSL files as text
- use `bundle-text:` when importing shaders

## Testing
- `npm run build` *(fails: parcel not found)*

------
https://chatgpt.com/codex/tasks/task_e_686284b394ec8323b03714d7f9207cab