### PR TITLE
Fix Parcel build by updating transformer

### DIFF
--- a/.parcelrc
+++ b/.parcelrc
@@ -1,6 +1,6 @@
 {
   "extends": "@parcel/config-default",
   "transformers": {
-    "*.glsl": ["@parcel/transformer-bundle-text"]
+    "*.glsl": ["@parcel/transformer-glsl", "@parcel/transformer-inline-string"]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "glslify-bundle": "^5.1.1",
         "glslify-deps": "^1.3.2",
         "parcel": "^2.15.4",
-        "sass": "^1.32.13"
+        "sass": "^1.32.13",
+        "@parcel/transformer-inline-string": "^2.15.4"
       }
     },
     "node_modules/@choojs/findup": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "glslify-deps": "^1.3.2",
     "parcel": "^2.15.4",
     "sass": "^1.32.13",
-    "@parcel/transformer-bundle-text": "^2.15.4"
+    "@parcel/transformer-inline-string": "^2.15.4"
   },
   "@parcel/transformer-glsl": {
     "version": 100


### PR DESCRIPTION
## Summary
- replace deprecated **@parcel/transformer-bundle-text** with **@parcel/transformer-inline-string**
- update Parcel config to process GLSL shaders through the GLSL transformer then inline them

## Testing
- `pre-commit` *(fails: not configured)*

------
https://chatgpt.com/codex/tasks/task_e_686285b92a4c8323a28c2571520b0fea