### PR TITLE
Fix FBO initialization order

### DIFF
--- a/src/scripts/gl/FBO.js
+++ b/src/scripts/gl/FBO.js
@@ -12,10 +12,6 @@ export default class FBO {
     this.targetA = this.createRenderTarget();
     this.targetB = this.createRenderTarget();
 
-    // Set initial positions
-    this.renderer.setRenderTarget(this.targetA);
-    this.renderer.render(this.getSimScene(), this.orthoCamera);
-    this.renderer.setRenderTarget(null);
 
     // Create particle system
     const geometry = new THREE.BufferGeometry();
@@ -47,9 +43,12 @@ export default class FBO {
     this.quad = new THREE.Mesh(plane, this.simulationMaterial);
     this.orthoScene.add(this.quad);
 
-    // Set initial texture
+    // Set initial texture and render once to populate render targets
     this.currentTarget = this.targetA;
     this.renderMaterial.uniforms.positions.value = this.targetA.texture;
+    this.renderer.setRenderTarget(this.targetA);
+    this.renderer.render(this.getSimScene(), this.orthoCamera);
+    this.renderer.setRenderTarget(null);
   }
 
   createRenderTarget() {


### PR DESCRIPTION
## Summary
- fix order of FBO setup so the orthographic camera exists before the initial render

## Testing
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68629a0fa1e083239c48caaaea42e4b5