### PR TITLE
Fix shader version issue

### DIFF
--- a/src/scripts/gl/shaders/simulation.frag.glsl
+++ b/src/scripts/gl/shaders/simulation.frag.glsl
@@ -1,4 +1,3 @@
-#version 100
 precision mediump float;
 
 uniform sampler2D positions; // Data Texture containing original positions

--- a/src/scripts/gl/shaders/simulation.vert.glsl
+++ b/src/scripts/gl/shaders/simulation.vert.glsl
@@ -1,4 +1,3 @@
-#version 100
 varying vec2 vUv;
 attribute vec2 position;
 


### PR DESCRIPTION
## Summary
- remove `#version` directive from GLSL shaders

## Testing
- `npm run build` *(fails: parcel not found)*

------
https://chatgpt.com/codex/tasks/task_e_68629b2de7c08323a0d4c5c298c25240