### PR TITLE
Fix shader compilation

### DIFF
--- a/src/scripts/gl/shaders/simulation.frag.glsl
+++ b/src/scripts/gl/shaders/simulation.frag.glsl
@@ -1,4 +1,3 @@
-#version 100
 precision mediump float;
 
 uniform sampler2D positions; // Data Texture containing original positions
@@ -10,8 +9,81 @@ varying vec2 vUv;
 
 #define PI 3.1415926538
 
-#pragma glslify: curl = require(glsl-curl-noise)
-#pragma glslify: noise = require(glsl-noise/classic/3d)
+
+// Simplex noise implementation from https://github.com/ashima/webgl-noise
+vec3 mod289(vec3 x) { return x - floor(x / 289.0) * 289.0; }
+vec4 mod289(vec4 x) { return x - floor(x / 289.0) * 289.0; }
+vec4 permute(vec4 x) { return mod289(((x * 34.0) + 1.0) * x); }
+vec4 taylorInvSqrt(vec4 r) { return 1.79284291400159 - 0.85373472095314 * r; }
+
+float noise(vec3 v) {
+  const vec2 C = vec2(1.0 / 6.0, 1.0 / 3.0);
+  const vec4 D = vec4(0.0, 0.5, 1.0, 2.0);
+
+  vec3 i = floor(v + dot(v, C.yyy));
+  vec3 x0 = v - i + dot(i, C.xxx);
+
+  vec3 g = step(x0.yzx, x0.xyz);
+  vec3 l = 1.0 - g;
+  vec3 i1 = min(g.xyz, l.zxy);
+  vec3 i2 = max(g.xyz, l.zxy);
+
+  vec3 x1 = x0 - i1 + C.xxx;
+  vec3 x2 = x0 - i2 + C.yyy;
+  vec3 x3 = x0 - D.yyy;
+
+  i = mod289(i);
+  vec4 p = permute(permute(permute(
+              i.z + vec4(0.0, i1.z, i2.z, 1.0))
+            + i.y + vec4(0.0, i1.y, i2.y, 1.0))
+            + i.x + vec4(0.0, i1.x, i2.x, 1.0));
+
+  float n_ = 1.0 / 7.0;
+  vec3 ns = n_ * D.wyz - D.xzx;
+
+  vec4 j = p - 49.0 * floor(p * ns.z * ns.z);
+
+  vec4 x_ = floor(j * ns.z);
+  vec4 y_ = floor(j - 7.0 * x_);
+
+  vec4 x = x_ * ns.x + ns.y;
+  vec4 y = y_ * ns.x + ns.y;
+  vec4 h = 1.0 - abs(x) - abs(y);
+
+  vec4 b0 = vec4(x.xy, y.xy);
+  vec4 b1 = vec4(x.zw, y.zw);
+
+  vec4 s0 = floor(b0) * 2.0 + 1.0;
+  vec4 s1 = floor(b1) * 2.0 + 1.0;
+  vec4 sh = -step(h, vec4(0.0));
+
+  vec4 a0 = b0.xzyw + s0.xzyw * sh.xxyy;
+  vec4 a1 = b1.xzyw + s1.xzyw * sh.zzww;
+
+  vec3 p0 = vec3(a0.xy, h.x);
+  vec3 p1 = vec3(a0.zw, h.y);
+  vec3 p2 = vec3(a1.xy, h.z);
+  vec3 p3 = vec3(a1.zw, h.w);
+
+  vec4 norm = taylorInvSqrt(vec4(dot(p0, p0), dot(p1, p1), dot(p2, p2), dot(p3, p3)));
+  p0 *= norm.x;
+  p1 *= norm.y;
+  p2 *= norm.z;
+  p3 *= norm.w;
+
+  vec4 m = max(0.6 - vec4(dot(x0, x0), dot(x1, x1), dot(x2, x2), dot(x3, x3)), 0.0);
+  m = m * m;
+
+  return 42.0 * dot(m * m, vec4(dot(p0, x0), dot(p1, x1), dot(p2, x2), dot(p3, x3)));
+}
+
+vec3 curl(vec3 p) {
+  float e = 0.1;
+  float dx = noise(vec3(p.x + e, p.y, p.z)) - noise(vec3(p.x - e, p.y, p.z));
+  float dy = noise(vec3(p.x, p.y + e, p.z)) - noise(vec3(p.x, p.y - e, p.z));
+  float dz = noise(vec3(p.x, p.y, p.z + e)) - noise(vec3(p.x, p.y, p.z - e));
+  return vec3(dy - dz, dz - dx, dx - dy) / (2.0 * e);
+}
 
 mat4 rotation3d(vec3 axis, float angle) {
   axis = normalize(axis);

--- a/src/scripts/gl/shaders/simulation.vert.glsl
+++ b/src/scripts/gl/shaders/simulation.vert.glsl
@@ -1,9 +1,8 @@
-#version 100
 varying vec2 vUv;
-attribute vec2 position;
 
 void main() {
   vUv = uv;
-  
-  gl_Position = vec4(position, 0.0, 1.0);
+
+  // Use the built in vertex position for the fullscreen quad
+  gl_Position = vec4(position, 1.0);
 }


### PR DESCRIPTION
## Summary
- remove custom position attribute from the simulation vertex shader
- implement simplex noise and curl helper functions directly in the simulation fragment shader so it compiles without glslify

## Testing
- `npm run build` *(fails: parcel not found)*

------
https://chatgpt.com/codex/tasks/task_e_68629b2de7c08323a0d4c5c298c25240