### PR TITLE
Update start script to build before launching Electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ This command uses Parcel to create a `dist` folder containing the production bui
 
 ## Running the Electron app
 
-After building the project, start the Electron application with:
+Run the following command to build the web files and launch the Electron window:
 
 ```bash
 npm start
 ```
 
-This launches a desktop window that loads the files from the `dist` folder.
+This command first runs `npm run build` to create the `dist` folder and then opens Electron using those files.
 
 ## Developing with live reload
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "parcel index.html",
     "build": "parcel build index.html",
-    "start": "npm run build && electron .",
+    "start": "npm run build && electron electron.js",
     "test": "echo \"No tests yet\""
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- adjust start script so `npm start` builds and runs the Electron app
- clarify usage in README

## Testing
- `npm run start` *(fails: parcel not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863804d642c8323967021ef2c936755