### PR TITLE
Configure npm start for Electron window

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Run the following command to build the web files and launch the Electron window:
 npm start
 ```
 
-This command first runs `npm run build` to create the `dist` folder and then opens Electron using those files.
+The `prestart` script automatically runs `npm run build` and then Electron opens the files from the `dist` folder.
 
 ## Developing with live reload
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "dev": "parcel index.html",
     "build": "parcel build index.html",
-    "start": "npm run build && electron electron.js",
+    "prestart": "npm run build",
+    "start": "electron .",
     "test": "echo \"No tests yet\""
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- build automatically when running `npm start`
- clarify how `npm start` works in the README

## Testing
- `npm run build` *(fails: parcel not found)*
- `npm start` *(fails: parcel not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863841b6e9883238d72256567342cd0